### PR TITLE
added additional note on generateInqualities method

### DIFF
--- a/jorlib-core/src/main/java/org/jorlib/frameworks/columngeneration/master/cutGeneration/AbstractCutGenerator.java
+++ b/jorlib-core/src/main/java/org/jorlib/frameworks/columngeneration/master/cutGeneration/AbstractCutGenerator.java
@@ -60,7 +60,10 @@ public abstract class AbstractCutGenerator<T extends ModelInterface, W extends M
     }
 
     /**
-     * Separate valid inequalities
+     * Separates valid inequalities, meaning that valid inequalities are identified and added to the model.
+     * <p>
+     * Note that this method should add the cuts to the master model, which can be achieved by calling the
+     * {@link #addCut(AbstractInequality)} method. 
      * 
      * @return returns a list of violated inequality which have been found
      */


### PR DESCRIPTION
Currently, the JavaDoc does not clearly state that this method should also add the inequalities to the model (in my opinion this is not necessarily inferred by the word separate). This has now been added as a note.

Maybe it would be a good idea to make this also more explicit in the name of the method or to incorporate this behaviour in CutGen.